### PR TITLE
FISH-8428 Update Payara Version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
         <cargo.version>1.6.7</cargo.version>
         <java.ee.version>9.1.0</java.ee.version>
 
-        <payara.version>7.2024.1-SNAPSHOT</payara.version>
+        <payara.version>7.2024.1.Alpha2-SNAPSHOT</payara.version>
         <data.source.class-name>org.h2.Driver</data.source.class-name> 
         <data.source.url>jdbc:h2:./tmp/cargo-tracker-database;AUTO_SERVER=TRUE</data.source.url>
         <payara.version.major>7</payara.version.major>


### PR DESCRIPTION
Cargotracker still uses a Maven resolver in the test which reads the pom as-is, meaning it ignores property overrides provided at the command line (like payara.version).
This means we need to keep it in sync