### PR TITLE
Fix PrimeFaces Theme Dependency - Master Branch

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -130,7 +130,7 @@
         </dependency>
         <dependency>
             <groupId>org.primefaces.themes</groupId>
-            <artifactId>ui-lightness</artifactId>
+            <artifactId>all-themes</artifactId>
             <version>${primefaces.theme.version}</version>
         </dependency>
 


### PR DESCRIPTION
PrimeFaces removed ui-lightness from their maven repository, but all-themes remained.

This hotfix passes tests, but doesn't fix the broken html pages! Primefaces removed layout and layoutUnit tags, which need to be rewritten.
