### PR TITLE
FISH-11911 FISH-12484 removing dependency that is not needed by latest version of Jersey 4.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -121,6 +121,11 @@
 
         <!-- GlassFish specific dependencies, could go away in Java EE 8 -->
         <dependency>
+            <groupId>org.glassfish.jersey.core</groupId>
+            <artifactId>jersey-server</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.glassfish.jersey.media</groupId>
             <artifactId>jersey-media-moxy</artifactId>
             <scope>provided</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -121,11 +121,6 @@
 
         <!-- GlassFish specific dependencies, could go away in Java EE 8 -->
         <dependency>
-            <groupId>org.glassfish.jersey.containers</groupId>
-            <artifactId>jersey-container-servlet-core</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>org.glassfish.jersey.media</groupId>
             <artifactId>jersey-media-moxy</artifactId>
             <scope>provided</scope>


### PR DESCRIPTION
This PR remove a dependency not needed with the upgrade of latest Jersey version 4.0.0.

From the implementation of Jersey they decided to remove the dependency jersey-container-servlet-core and now all classes and components were merged into the dependency jersey-container-servlet