### PR TITLE
FISH-10759 Deployment Descriptors

### DIFF
--- a/src/main/webapp/WEB-INF/payara-web.xml
+++ b/src/main/webapp/WEB-INF/payara-web.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE glassfish-web-app PUBLIC "-//GlassFish.org//DTD GlassFish Application Server 3.1 Servlet 3.0//EN" "http://glassfish.org/dtds/glassfish-web-app_3_0-1.dtd">
-<glassfish-web-app>
+<!DOCTYPE payara-web-app PUBLIC "-//Payara.fish//DTD Payara Server 4 Servlet 3.0//EN" "https://docs.payara.fish/schemas/payara-web-app_4.dtd">
+<payara-web-app>
     <context-root>/cargo-tracker</context-root>
     <class-loader delegate="true"/>
     <jsp-config>
@@ -8,4 +8,4 @@
             <description>Keep a copy of the generated servlet class' java code.</description>
         </property>
     </jsp-config>
-</glassfish-web-app>
+</payara-web-app>


### PR DESCRIPTION
Replaces the `glassfish-web.xml` file with an equivalent `payara-web.xml`.

Required for [FISH-10759](https://github.com/payara/Payara/pull/7925).

[FISH-10759]: https://payara.atlassian.net/browse/FISH-10759?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ